### PR TITLE
Replaced forbidden characters in course name by an empty string

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -16,13 +16,11 @@ if (isWindowOpen(anchorTag)) {
 
 }
 
-console.log(url);
-
-const courseName = document.getElementsByClassName("page-header-headings")[0]
+const baseCourseName = document.getElementsByClassName("page-header-headings")[0]
   .children[0].innerHTML;
 
+const courseName = baseCourseName.replace(/[*?"<>|\\\/:]/g, "").trim();
 chrome.runtime.sendMessage({ url: url, courseName: courseName, extension: extension });
-
 
 
 function isWindowOpen(a) {


### PR DESCRIPTION
Fix issue #2 
I added a regex to find the forbidden characters and replace them with an empty string. 
I also trimmed the string to remove any blank space before or after the course name.