### PR TITLE
Fetch html code from item url to get the right downloadable url

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -12,9 +12,14 @@ chrome.runtime.onMessage.addListener(msg => {
 })
 
 chrome.downloads.onDeterminingFilename.addListener((item, suggest) => {
+  if(item.filename == "view.html") {
+    downloadFromFrame(item);
+    chrome.downloads.cancel(item.id);
+  }
   const suffix = hasExtension(item.filename) ? '' : extension
   suggest({ filename: prefix + item.filename + suffix })
 })
+
 
 function downloadFiles(resources) {
   Array.prototype.forEach.call(resources, downloadFile)
@@ -29,4 +34,21 @@ function downloadFile(resource) {
 
 function hasExtension(fileName) {
   return fileName.indexOf('.') > -1
+}
+
+function downloadFromFrame(item) {
+  fetch(item.url).then((data) => {
+    return data.text();
+  })
+  .then( (text) => {
+    const anchor = "frame src=";
+    const offset = anchor.length + 1;
+    const first = text.indexOf(anchor, text.indexOf(anchor) + offset);
+    
+    if (first > -1) {
+      const second = text.indexOf("\"", first + offset);
+      const url = text.substring(first + offset, second);
+      downloadFile({extension: '.pdf', url: url});
+    }
+  });
 }


### PR DESCRIPTION
I fetched html code from the item's url to get the pdf's downloadble link in the frameset.
This is related to issue #7 